### PR TITLE
build: Cache dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,13 @@
 
 name: Python package
 
-on: pull_request
+# Trigger pipeline if commit pushed to master (merge) or during any pull request
+# See also: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-multiple-events-with-activity-types-or-configuration
+on:
+  push:
+    branches:
+      - master
+  pull_request:     # Even without configuration `:` must be appended
 
 jobs:
   build:
@@ -12,30 +18,37 @@ jobs:
       matrix:
         python-version: [3.7]
 
+    # Pipeline steps
     steps:
     - uses: actions/checkout@v2
+    # Caching stores the dependencies so that subsequent runs are faster (cache duration: 7 days)
+    # Template: https://github.com/actions/cache/blob/master/examples.md#python---pip
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip                                         # pip stores cached files here by default
+        key: cache-pip-${{ hashFiles('**/requirements.txt') }}     # Lookup key - if .txt changes new cache will be set up
+        restore-keys: |                                            # Fallback lookup key(s) if main key not found in cache
+          cache-pip-
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+
     - name: Test with pytest
       run: |
         pip install pytest
         pip install pytest pytest-cov
         pip install codecov
         pytest --cov=./ --cov-report xml
+
     - name: Codecov
       uses: codecov/codecov-action@v1.0.6
       with:
-        # User defined upload name. Visible in Codecov UI
-        name: py-template
-        # Repository upload token - get it from codecov.io. Required only for private repositories
-        token: ${{ secrets.CODECOV_TOKEN }}
-        # # Path to coverage file to upload
-        # file: # optional
-        # # Flag upload to group coverage metrics (e.g. unittests | integration | ui,chrome)
-        # flags: # optional
+        name: py-template                     # User defined upload name. Visible in Codecov UI
+        token: ${{ secrets.CODECOV_TOKEN }}   # Repository upload token - get it from codecov.io. Required only for private repositories


### PR DESCRIPTION
Without caching, every time the pipeline is triggered, the python packages required for the build will be re-downloaded. By setting up a cache, they will persist and be re-used across runs.